### PR TITLE
Bugfix: Add an environmental variable for the authentication token

### DIFF
--- a/DD2480-CI/.gitignore
+++ b/DD2480-CI/.gitignore
@@ -36,3 +36,6 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+### Github token ###
+../.env

--- a/DD2480-CI/pom.xml
+++ b/DD2480-CI/pom.xml
@@ -82,6 +82,12 @@
             <version>1.10.1</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+            <version>3.0.0</version>
+        </dependency>
         
     </dependencies>
 

--- a/DD2480-CI/src/main/java/skeleton/GitStatusUpdate.java
+++ b/DD2480-CI/src/main/java/skeleton/GitStatusUpdate.java
@@ -1,5 +1,6 @@
 package skeleton;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -15,7 +16,7 @@ public class GitStatusUpdate {
     private final BuildStatus buildStatus;
     private final String gitUri;
     private final String sha;
-    private final String githubToken;
+    private String githubToken;
 
     /**
      * Constructor for the GitStatusUpdate class
@@ -27,7 +28,7 @@ public class GitStatusUpdate {
         this.sha = sha;
         this.buildStatus = buildStatus;
         this.gitUri = "https://api.github.com/";
-        this.githubToken = System.getenv("ci_token"); // make sure this works
+        this.githubToken = Dotenv.configure().load().get("ci_token");
     }
 
     /**


### PR DESCRIPTION
Fix #17
Move authentication token to an .env file (that the user will have configure themselves), and add dependency for Dotenv
which enables reading an environmental variable from a .env file